### PR TITLE
To signal the end of tests, now need to use done-testing()

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -6,5 +6,5 @@ use Test;
 
 use-ok('Log::Syslog::Native');
 
-done();
+done-testing();
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/t/02-syslog.t
+++ b/t/02-syslog.t
@@ -30,5 +30,5 @@ for @levs -> $lev {
    lives-ok { $obj."$meth"("[TEST] - test $meth method") }, "$meth method";
 }
 
-done();
+done-testing();
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
This module fails tests when installed via panda now that glr has been merged into nom. It seems like the only problem is that the test files need to end with `done-testing()` instead of `done()`.

This is my first pull request so let me know if I've done something incorrectly. Thanks for writing this module!
