### PR TITLE
Fix explicitly-manage routine usage

### DIFF
--- a/lib/Log/Syslog/Native.pm
+++ b/lib/Log/Syslog/Native.pm
@@ -287,8 +287,7 @@ Log to stderr as well
     submethod BUILD(:$!ident = $*PROGRAM-NAME, :$option, :$facility) {
         $!option = $option // Pid +| ODelay;
         $!facility = $facility // Local0;
-        my $i = $!ident;
-        explicitly-manage($i);
+        my $i = explicitly-manage($!ident);
         _openlog($i, $!option, $!facility);
     }
 


### PR DESCRIPTION
The explicitly-manage returns externally using string instead of making the original string uncollectable by GC.
Pass the result of explicitly-manage to native call now.

Solve #4 